### PR TITLE
Merge static tracing from Analyzer

### DIFF
--- a/src/Traceur.jl
+++ b/src/Traceur.jl
@@ -6,9 +6,10 @@ using ASTInterpreter2: linearize!
 
 import Core.MethodInstance
 
-export @trace
+export @trace, @trace_static
 
 include("analysis.jl")
 include("trace.jl")
+include("trace_static.jl")
 
 end # module

--- a/src/Traceur.jl
+++ b/src/Traceur.jl
@@ -4,6 +4,8 @@ using MacroTools
 using Vinyl: @primitive, overdub
 using ASTInterpreter2: linearize!
 
+import Core.MethodInstance
+
 export @trace
 
 include("analysis.jl")

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -37,12 +37,7 @@ argtypes(c::StaticCall) = Tuple{c.method_instance.specTypes.parameters[2:end]...
 types(c::StaticCall) = c.method_instance.specTypes
 method(c::StaticCall) = c.method_instance.def
 
-function method_expr(c::StaticCall)
-  name = GlobalRef(method(c).module, method(c).name)
-  args = join(["::$typ" for typ in argtypes(c)], ", ")
-  # TODO can't return a nice expr for types without args. string will do for now
-  "$name($args)"
-end
+method_expr(c::StaticCall) = method_expr(method(c).name, argtypes(c))
 
 function code(c::StaticCall; optimize = false)
   # TODO static call graph can only be computed with optimize=true, so analyzing with optimized=false will skip inlined methods

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -22,19 +22,7 @@ end
 
 trace(w, f) = overdub(Trace(w), f)
 
-function warntrace(f)
-  call = nothing
-  function warn(w)
-    if (w.f, w.a) != call
-      call = (w.f, w.a)
-      method = which(w.f, w.a)
-      print_with_color(:yellow, method_expr(call...),
-                       " at $(method.file):$(method.line)", '\n')
-    end
-    println("  ", w.message, w.line != -1 ? " at line $(w.line)" : "")
-  end
-  trace(warn, f)
-end
+warntrace(f) = trace(warning_printer(), f)
 
 function warnings(f)
   warnings = Warning[]

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -10,7 +10,7 @@ isprimitive(f) = f isa Core.Builtin || f isa Core.IntrinsicFunction
 const ignored_methods = [@which((1,2)[1])]
 
 @primitive ctx::Trace function (f::Any)(args...)
-  C, T = Call(f, args...), typeof.((f, args...))
+  C, T = DynamicCall(f, args...), typeof.((f, args...))
   (T ∈ ctx.seen || isprimitive(f) ||
     method(C) ∈ ignored_methods ||
     method(C).module ∈ [Core, Core.Inference]) && return f(args...)

--- a/src/trace_static.jl
+++ b/src/trace_static.jl
@@ -120,3 +120,9 @@ warntrace_static(f::Function, typs) = warntrace_static((_) -> true, f, typs)
     expr
   end
 end
+
+function warnings_static(f)
+  warnings = Warning[]
+  trace_static((_) -> true, w -> push!(warnings, w), f, ())
+  return warnings
+end

--- a/src/trace_static.jl
+++ b/src/trace_static.jl
@@ -1,0 +1,135 @@
+function get_method_instance(f, typs) ::MethodInstance
+  world = ccall(:jl_get_world_counter, UInt, ())
+  tt = typs isa Type ? Tuple{typeof(f), typs.parameters...} : Tuple{typeof(f), typs...}
+  results = Base._methods_by_ftype(tt, -1, world)
+  @assert length(results) == 1 "get_method_instance should return one method, instead returned $(length(results)) methods: $results"
+  (_, _, meth) = results[1]
+  # TODO not totally sure what jl_match_method is needed for - I think it's just extracting type parameters like `where {T}`
+  (ti, env) = ccall(:jl_match_method, Any, (Any, Any), tt, meth.sig)::SimpleVector
+  meth = Base.func_for_method_checked(meth, tt)
+  linfo = ccall(:jl_specializations_get_linfo, Ref{MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
+end
+
+function get_code_info(method_instance::MethodInstance; optimize=true) ::Tuple{CodeInfo, Type}
+  world = ccall(:jl_get_world_counter, UInt, ())
+  # TODO inlining=false would make analysis easier to follow, but it seems to break specialization on function types
+  params = Core.Inference.InferenceParams(world)
+  optimize = true
+  cache = false # not sure if cached copies use the same params
+  (_, code_info, return_typ) = Core.Inference.typeinf_code(method_instance, optimize, cache, params)
+  (code_info, return_typ)
+end
+
+"Does this look like error reporting code ie not worth looking inside?"
+function is_error_path(expr)
+  expr == :throw ||
+  expr == :throw_boundserror ||
+  expr == :error ||
+  expr == :assert ||
+  (expr isa QuoteNode && is_error_path(expr.value)) ||
+  (expr isa Expr && expr.head == :(.) && is_error_path(expr.args[2])) ||
+  (expr isa GlobalRef && is_error_path(expr.name)) ||
+  (expr isa MethodInstance && is_error_path(expr.def.name))
+end
+
+"Is it pointless to look inside this expression?"
+function should_ignore(expr::Expr)
+  is_error_path(expr.head) ||
+  (expr.head == :call && is_error_path(expr.args[1])) ||
+  (expr.head == :invoke && is_error_path(expr.args[1]))
+end
+
+"Return all function calls in the method whose argument types can be determined statically"
+function get_child_calls(method_instance::MethodInstance)
+  code_info, return_typ = get_code_info(method_instance, optimize=true)
+  calls = Set{MethodInstance}()
+
+  function walk_expr(expr)
+    if isa(expr, MethodInstance)
+      push!(calls, expr)
+    elseif isa(expr, Expr)
+      if !should_ignore(expr)
+        foreach(walk_expr, expr.args)
+      end
+    end
+  end
+  foreach(walk_expr, code_info.code)
+
+  calls
+end
+
+"A node in the call graph"
+struct CallNode
+  call::MethodInstance
+  parent_calls::Set{MethodInstance}
+  child_calls::Set{MethodInstance}
+end
+
+"Return as much of the call graph of `method_instance` as can be determined statically"
+function get_call_graph(method_instance::MethodInstance, max_calls=1000::Int64) ::Vector{CallNode}
+  all = Dict{MethodInstance, CallNode}()
+  ordered = Vector{MethodInstance}()
+  unexplored = Set{Tuple{Union{Void, MethodInstance}, MethodInstance}}(((nothing, method_instance),))
+  for _ in 1:max_calls
+    if isempty(unexplored)
+      return [all[call] for call in ordered]
+    end
+    (parent, call) = pop!(unexplored)
+    child_calls= get_child_calls(call)
+    parent_calls = parent == nothing ? Set() : Set((parent,))
+    all[call] = CallNode(call, parent_calls, child_calls)
+    push!(ordered, call)
+    for child_call in child_calls
+      if !haskey(all, child_call)
+        push!(unexplored, (call, child_call))
+      else
+        push!(all[child_call].parent_calls, call)
+      end
+    end
+  end
+  error("get_call_graph reached $max_calls calls and gave up")
+end
+
+@generated function show_structure(x)
+  quote
+    @show x
+    $([:(isdefined(x, $(Expr(:quote, fieldname))) ? (@show x.$fieldname) : nothing) for fieldname in fieldnames(x)]...)
+    x
+  end
+end
+
+function trace_static(filter::Function, warn::Function, f::Function, typs)
+  for call_node in get_call_graph(get_method_instance(f, typs))
+    if filter(call_node.call)
+      analyse((a...) -> warn(Warning(a...)), StaticCall(call_node.call))
+    end
+  end
+end
+
+function tracewarn_static(filter::Function, f::Function, typs)
+  call = nothing
+  function warn(w)
+    if (w.f, w.a) != call
+      call = (w.f, w.a)
+      meth = method(w.f)
+      print_with_color(:yellow, method_expr(call...),
+      " at $(meth.file):$(meth.line)", '\n')
+    end
+    println("  ", w.message, w.line != -1 ? " at line $(w.line)" : "")
+  end
+  trace_static(filter, warn, f, typs)
+end
+
+tracewarn_static(f::Function, typs) = tracewarn_static((_) -> true, f, typs)
+
+@eval begin
+  macro trace_static(ex0)
+    Base.gen_call_with_extracted_types($(Expr(:quote, :tracewarn_static)), ex0)
+  end
+
+  macro trace_static(filter, ex0)
+    expr = Base.gen_call_with_extracted_types($(Expr(:quote, :tracewarn_static)), ex0)
+    insert!(expr.args, 2, esc(filter))
+    expr
+  end
+end

--- a/src/trace_static.jl
+++ b/src/trace_static.jl
@@ -106,29 +106,16 @@ function trace_static(filter::Function, warn::Function, f::Function, typs)
   end
 end
 
-function tracewarn_static(filter::Function, f::Function, typs)
-  call = nothing
-  function warn(w)
-    if (w.f, w.a) != call
-      call = (w.f, w.a)
-      meth = method(w.f)
-      print_with_color(:yellow, method_expr(call...),
-      " at $(meth.file):$(meth.line)", '\n')
-    end
-    println("  ", w.message, w.line != -1 ? " at line $(w.line)" : "")
-  end
-  trace_static(filter, warn, f, typs)
-end
-
-tracewarn_static(f::Function, typs) = tracewarn_static((_) -> true, f, typs)
+warntrace_static(filter::Function, f::Function, typs) = trace_static(filter, warning_printer(), f, typs)
+warntrace_static(f::Function, typs) = warntrace_static((_) -> true, f, typs)
 
 @eval begin
   macro trace_static(ex0)
-    Base.gen_call_with_extracted_types($(Expr(:quote, :tracewarn_static)), ex0)
+    Base.gen_call_with_extracted_types($(Expr(:quote, :warntrace_static)), ex0)
   end
 
   macro trace_static(filter, ex0)
-    expr = Base.gen_call_with_extracted_types($(Expr(:quote, :tracewarn_static)), ex0)
+    expr = Base.gen_call_with_extracted_types($(Expr(:quote, :warntrace_static)), ex0)
     insert!(expr.args, 2, esc(filter))
     expr
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using Traceur: warnings, @trace
+using Traceur
+using Traceur: warnings
 using Base.Test
 
 warns_for(ws, x) = any(w -> contains(w.message, x), ws)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,4 +38,6 @@ ws = warnings(() -> f(1))
 
 @test_nowarn @trace naive_sum(1.0)
 
+@test_nowarn @trace_static naive_sum(1.0)
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Traceur
-using Traceur: warnings
 using Base.Test
 
 warns_for(ws, x) = any(w -> contains(w.message, x), ws)
@@ -7,15 +6,7 @@ warns_for(ws, x, xs...) = warns_for(ws, x) && warns_for(ws, xs...)
 
 y = 1
 
-@testset "Traceur" begin
-
 naive_relu(x) = x < 0 ? 0 : x
-
-ws = warnings(() -> naive_relu(1))
-@test isempty(ws)
-
-ws = warnings(() -> naive_relu(1.0))
-@test warns_for(ws, "returns")
 
 function naive_sum(xs)
   s = 0
@@ -25,19 +16,35 @@ function naive_sum(xs)
   return s
 end
 
-ws = warnings(() -> naive_sum(1))
-@test isempty(ws)
-
-ws = warnings(() -> naive_sum(1.0))
-@test warns_for(ws, "assigned", "dispatch", "returns")
-
 f(x) = x+y
 
-ws = warnings(() -> f(1))
-@test warns_for(ws, "global", "dispatch", "returns")
+function test(warnings)
+  ws = warnings(() -> naive_relu(1))
+  @test isempty(ws)
 
-@test_nowarn @trace naive_sum(1.0)
+  ws = warnings(() -> naive_relu(1.0))
+  @test warns_for(ws, "returns")
 
-@test_nowarn @trace_static naive_sum(1.0)
+  ws = warnings(() -> naive_sum(1))
+  @test isempty(ws)
+
+  ws = warnings(() -> naive_sum(1.0))
+  @test warns_for(ws, "assigned", "dispatch", "returns")
+
+  ws = warnings(() -> f(1))
+  @test warns_for(ws, "global", "dispatch", "returns")
+end
+
+@testset "Traceur" begin
+  @testset "Dynamic" begin
+    test(Traceur.warnings)
+  end
+  @testset "Static" begin
+    test(Traceur.warnings_static)
+  end
+  @test_nowarn @trace naive_sum(1.0)
+  @test_nowarn @trace_static naive_sum(1.0)
+end
+
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Traceur: warnings
+using Traceur: warnings, @trace
 using Base.Test
 
 warns_for(ws, x) = any(w -> contains(w.message, x), ws)
@@ -34,5 +34,7 @@ f(x) = x+y
 
 ws = warnings(() -> f(1))
 @test warns_for(ws, "global", "dispatch", "returns")
+
+@test_nowarn @trace naive_sum(1.0)
 
 end


### PR DESCRIPTION
This is a bit tricky because all the reflection functions take (function, argtypes) but the static tracing can't get actual functions, only function types. So I have lots of sketchy calls into Julia internals to reproduce what `code_typed` etc do. I added `StaticCall, DynamicCall <: Call` to keep this muck separate from the existing Traceur code as much as possible. 

I'm not sure what to do about unifying the interface. The options and defaults for each are going to be different so passing that stuff through will be a pain. Left to myself I would get rid off the callbacks and do something like:

``` julia
function trace(f; tracer=DynamicTracer())
  call_graph = call_graph(f, tracer)
  warnings = warnings(call_graph)
  print_warnings(warnings)
end

call_graph(f, tracer::DynamicTracer) = ...
call_graph(f, tracer::StaticTracer) = ...

warnings(call_graph) = [(call, analyze(call)) for call in call_graph)]
```