### PR TITLE
Discussion: Add assert_trace option to assert on the first Trace warning.

### DIFF
--- a/src/trace.jl
+++ b/src/trace.jl
@@ -38,3 +38,9 @@ end
 macro trace(ex)
   :(warntrace(() -> $(esc(ex))))
 end
+
+assert_trace(f) = trace((w)->@assert(false, w.message), f)
+
+macro assert_trace(ex)
+  :(assert_trace(() -> $(esc(ex))))
+end


### PR DESCRIPTION
Adds `@assert_trace` which raises an `AssertError` at the first Trace warning.

@pfitzseb Asked me to open a PR for this. It relates to https://github.com/MikeInnes/Traceur.jl/issues/6.

I'm not sure this is really a good solution, though, because this means it stops at the _first_ warning, which could be desirable or not. Also, it's not a great _testing_ interface, it'd be better if it returned false or something instead of throwing an `AssertError`. (Of course one/we can always wrap this in a `try`/`catch` to return false.)