### PR TITLE
add parens to string interpolation

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -140,7 +140,7 @@ function locals(warn, call)
     var = c.slotnames[x.id]
     startswith(string(var), '#') && continue
     for (l, t) in as
-      warn(call, l, "$var is assigned as $t")
+      warn(call, l, "$(var) is assigned as $(t)")
     end
   end
 end


### PR DESCRIPTION
I'm not sure why, but I wasn't able to precompile with julia 1.3 until I added these parens. It shouldn't change anything.