### PR TITLE
Start testing on Julia 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 1.0
+  - 1.1
   - 1.2
   - nightly
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:


### PR DESCRIPTION
This pull request:
- Enables Travis on Julia 1.2

Travis remains enabled for Julia 1.0 and 1.1.