### PR TITLE
Add `nowarn=:all` option to `@check` and `check`

### DIFF
--- a/src/check.jl
+++ b/src/check.jl
@@ -44,7 +44,7 @@ function check(f; nowarn=Any[], kwargs...)
       failed = true
     end
   end
-  @assert !failed "One or more warnings occured inside functions tagged with `@should_not_warn or specified with `nowarn`"
+  @assert !failed "One or more warnings occured inside functions tagged with `@should_not_warn` or specified with `nowarn`"
   result
 end
 

--- a/src/check.jl
+++ b/src/check.jl
@@ -16,17 +16,25 @@ macro should_not_warn(expr)
 end
 
 """
-    check(f::Function)
+    check(f::Function; nowarn=[], kwargs...)
 
 Run Traceur on `f`, and throw an error if any warnings occur inside functions
-tagged with `@should_not_warn`.
+tagged with `@should_not_warn` or specified in `nowarn`. To throw an error
+if any warnings occur inside any functions, set `nowarn=:all`.
 """
 function check(f; nowarn=Any[], kwargs...)
+  if nowarn isa Symbol
+    _nowarn = Any[]
+    _nowarn_all = nowarn == :all
+  else
+    _nowarn = nowarn
+    _nowarn_all = false
+  end
   failed = false
   wp = warning_printer()
   result = trace(f; kwargs...) do warning
     ix = findfirst(warning.stack) do call
-      call.f in should_not_warn || call.f in nowarn
+      _nowarn_all || call.f in should_not_warn || call.f in _nowarn
     end
     if ix != nothing
       tagged_function = warning.stack[ix].f
@@ -36,7 +44,7 @@ function check(f; nowarn=Any[], kwargs...)
       failed = true
     end
   end
-  @assert !failed "One or more warnings occured inside functions tagged with `@should_not_warn`"
+  @assert !failed "One or more warnings occured inside functions tagged with `@should_not_warn or specified with `nowarn`"
   result
 end
 
@@ -44,7 +52,8 @@ end
     @check fun(args...) nowarn=[] maxdepth=typemax(Int)
 
 Run Traceur on `fun`, and throw an error if any warnings occur inside functions
-tagged with `@should_not_warn` or specified in `nowarn`.
+tagged with `@should_not_warn` or specified in `nowarn`. To throw an error
+if any warnings occur inside any functions, set `nowarn=:all`.
 """
 macro check(expr, args...)
   quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ function naive_sum(xs)
   return s
 end
 
-foo(x) = x+y
+f(x) = x+y
 
 function f2(x)
   foo = y
@@ -63,7 +63,7 @@ my_stable_add_undecorated(y) = my_add(y)
   ws = Traceur.warnings(() -> naive_sum([1.0]))
   @test warns_for(ws, "assigned", "returns")
 
-  ws = Traceur.warnings(() -> foo(1))
+  ws = Traceur.warnings(() -> f(1))
   @test warns_for(ws, "global", "dispatch", "returns")
 
   ws = Traceur.warnings(() -> f2(1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ function naive_sum(xs)
   return s
 end
 
-f(x) = x+y
+foo(x) = x+y
 
 function f2(x)
   foo = y
@@ -63,7 +63,7 @@ my_stable_add_undecorated(y) = my_add(y)
   ws = Traceur.warnings(() -> naive_sum([1.0]))
   @test warns_for(ws, "assigned", "returns")
 
-  ws = Traceur.warnings(() -> f(1))
+  ws = Traceur.warnings(() -> foo(1))
   @test warns_for(ws, "global", "dispatch", "returns")
 
   ws = Traceur.warnings(() -> f2(1))
@@ -100,5 +100,23 @@ my_stable_add_undecorated(y) = my_add(y)
     @test_nowarn @check my_add(1)
     @test_throws AssertionError @check my_stable_add(1)
     @test_throws AssertionError @check my_stable_add_undecorated(1) nowarn=[my_stable_add_undecorated]
+    @test_throws AssertionError @check my_stable_add_undecorated(1) nowarn=:all
+    function bar(x)
+      x > 0 ? 1.0 : 1
+    end
+    @test @check(bar(2)) == 1.0
+    @test @check(bar(2), maxdepth=100) == 1.0
+    @test @check(bar(2), nowarn=:none) == 1.0
+    @test @check(bar(2), nowarn=:none, maxdepth=100) == 1.0
+    @test @check(bar(2), nowarn=[]) == 1.0
+    @test @check(bar(2), nowarn=[], maxdepth=100) == 1.0
+    @test @check(bar(2), nowarn=Any[]) == 1.0
+    @test @check(bar(2), nowarn=Any[], maxdepth=100) == 1.0
+    @test_throws AssertionError @check(bar(2), nowarn=[bar])
+    @test_throws AssertionError @check(bar(2), nowarn=[bar], maxdepth=100)
+    @test_throws AssertionError @check(bar(2), nowarn=Any[bar])
+    @test_throws AssertionError @check(bar(2), nowarn=Any[bar], maxdepth=100)
+    @test_throws AssertionError @check(bar(2), nowarn=:all)
+    @test_throws AssertionError @check(bar(2), nowarn=:all, maxdepth=100)
   end
 end


### PR DESCRIPTION
Related to #6. Closes #21. 

Currently, there are two ways to ask `check`/`@check` to throw an error if any warnings occur inside a function:
- Annotate the function definition with the `@should_not_warn` macro.
- Provide a list of functions in the `nowarn` keyword argument to `check`/`@check`. Example usage: `@check f(x,y,z) nowarn=[g,h]`

This pull request adds a third option:
- Set `nowarn=:all`, which tells `check`/`@check`to throw an error if any warnings occur inside ANY function. Example usage: `@check f(x) nowarn=:all`

The first two options remain available.

## Motivation

The first option (annotating with `@should_not_warn`) requires that you manually annotate all of the functions of interest. This can be cumbersome. Additionally, this requires that you make `Traceur.jl` a required dependency of your package, instead of a test-only dependency.

The second option (providing a list of functions in `nowarn`) requires that you manually list out all of the functions of interest. This can also be cumbersome.

The third option added in this pull request (setting `nowarn=:all`) is quick and easy.