### PR TITLE
Add `nowarn=:allexcept` and `except=[f, g, h, ...]` options to `@check` and `check`

### DIFF
--- a/src/check.jl
+++ b/src/check.jl
@@ -16,25 +16,40 @@ macro should_not_warn(expr)
 end
 
 """
-    check(f::Function; nowarn=[], kwargs...)
+    check(f::Function; nowarn=[], except=[], kwargs...)
 
 Run Traceur on `f`, and throw an error if any warnings occur inside functions
-tagged with `@should_not_warn` or specified in `nowarn`. To throw an error
-if any warnings occur inside any functions, set `nowarn=:all`.
+tagged with `@should_not_warn` or specified in `nowarn`.
+
+To throw an error if any warnings occur inside any functions, set
+`nowarn=:all`.
+
+To throw an error if any warnings occur inside any functions EXCEPT for a
+certain set of functions, set `nowarn=:allexcept` and list the exceptions in
+the `except` variable, i.e. set `except=[f, g, h, ...]`
 """
-function check(f; nowarn=Any[], kwargs...)
+function check(f; nowarn=Any[], except=Any[], kwargs...)
   if nowarn isa Symbol
     _nowarn = Any[]
-    _nowarn_all = nowarn == :all
+    if nowarn == :all
+      _nowarn_all = true
+      _nowarn_allexcept = false
+    elseif nowarn == :allexcept
+      _nowarn_all = false
+      _nowarn_allexcept = true
+    else
+      throw(ArgumentError(":$(nowarn) is not a valid value for nowarn"))
+    end
   else
     _nowarn = nowarn
     _nowarn_all = false
+    _nowarn_allexcept = false
   end
   failed = false
   wp = warning_printer()
   result = trace(f; kwargs...) do warning
     ix = findfirst(warning.stack) do call
-      _nowarn_all || call.f in should_not_warn || call.f in _nowarn
+      _nowarn_all || call.f in should_not_warn || call.f in _nowarn || (_nowarn_allexcept && !(call.f in except))
     end
     if ix != nothing
       tagged_function = warning.stack[ix].f
@@ -49,11 +64,17 @@ function check(f; nowarn=Any[], kwargs...)
 end
 
 """
-    @check fun(args...) nowarn=[] maxdepth=typemax(Int)
+    @check fun(args...) nowarn=[] except=[] maxdepth=typemax(Int)
 
 Run Traceur on `fun`, and throw an error if any warnings occur inside functions
-tagged with `@should_not_warn` or specified in `nowarn`. To throw an error
-if any warnings occur inside any functions, set `nowarn=:all`.
+tagged with `@should_not_warn` or specified in `nowarn`.
+
+To throw an error if any warnings occur inside any functions, set
+`nowarn=:all`.
+
+To throw an error if any warnings occur inside any functions EXCEPT for a
+certain set of functions, set `nowarn=:allexcept` and list the exceptions in
+the `except` variable, i.e. set `except=[f, g, h, ...]`
 """
 macro check(expr, args...)
   quote

--- a/src/check.jl
+++ b/src/check.jl
@@ -25,26 +25,23 @@ To throw an error if any warnings occur inside any functions, set
 `nowarn=:all`.
 
 To throw an error if any warnings occur inside any functions EXCEPT for a
-certain set of functions, set `nowarn=:allexcept` and list the exceptions in
-the `except` variable, i.e. set `except=[f, g, h, ...]`
+certain set of functions, list the exceptions in the `except` variable,
+for example `except=[f,g,h]`
 """
 function check(f; nowarn=Any[], except=Any[], kwargs...)
-  if nowarn isa Symbol
+  if !isempty(except) # if `except` is provided, we ignore the value of `nowarn`
     _nowarn = Any[]
-    if nowarn == :all
-      _nowarn_all = true
-      _nowarn_allexcept = false
-    elseif nowarn == :allexcept
-      _nowarn_all = false
-      _nowarn_allexcept = true
-    else
-      throw(ArgumentError(":$(nowarn) is not a valid value for nowarn"))
-    end
+    _nowarn_all = false
+    _nowarn_allexcept = true
+  elseif nowarn isa Symbol
+    _nowarn = Any[]
+    _nowarn_all = nowarn == :all
+    _nowarn_allexcept = false
   else
     _nowarn = nowarn
     _nowarn_all = false
     _nowarn_allexcept = false
-  end
+  end  
   failed = false
   wp = warning_printer()
   result = trace(f; kwargs...) do warning
@@ -73,8 +70,8 @@ To throw an error if any warnings occur inside any functions, set
 `nowarn=:all`.
 
 To throw an error if any warnings occur inside any functions EXCEPT for a
-certain set of functions, set `nowarn=:allexcept` and list the exceptions in
-the `except` variable, i.e. set `except=[f, g, h, ...]`
+certain set of functions, list the exceptions in the `except` variable,
+for example `except=[f,g,h]`
 """
 macro check(expr, args...)
   quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,9 +133,9 @@ my_stable_add_undecorated(y) = my_add(y)
     @test_throws AssertionError @check(bar(2), nowarn=Any[bar], maxdepth=100)
     @test_throws AssertionError @check(bar(2), nowarn=:all)
     @test_throws AssertionError @check(bar(2), nowarn=:all, maxdepth=100)
-    @test_nowarn @check(bar(2), nowarn=:allexcept, except=[bar]) == 1.0
-    @test_nowarn @check(bar(2), nowarn=:allexcept, except=[bar], maxdepth=100) == 1.0
-    @test_nowarn @check(bar(2), nowarn=:allexcept, except=Any[bar]) == 1.0
-    @test_nowarn @check(bar(2), nowarn=:allexcept, except=Any[bar], maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2), except=[bar]) == 1.0
+    @test_nowarn @check(bar(2), except=[bar], maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2), except=Any[bar]) == 1.0
+    @test_nowarn @check(bar(2), except=Any[bar], maxdepth=100) == 1.0
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,19 +121,21 @@ my_stable_add_undecorated(y) = my_add(y)
     function bar(x)
       x > 0 ? 1.0 : 1
     end
-    @test @check(bar(2)) == 1.0
-    @test @check(bar(2), maxdepth=100) == 1.0
-    @test @check(bar(2), nowarn=:none) == 1.0
-    @test @check(bar(2), nowarn=:none, maxdepth=100) == 1.0
-    @test @check(bar(2), nowarn=[]) == 1.0
-    @test @check(bar(2), nowarn=[], maxdepth=100) == 1.0
-    @test @check(bar(2), nowarn=Any[]) == 1.0
-    @test @check(bar(2), nowarn=Any[], maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2)) == 1.0
+    @test_nowarn @check(bar(2), maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2), nowarn=[]) == 1.0
+    @test_nowarn @check(bar(2), nowarn=[], maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2), nowarn=Any[]) == 1.0
+    @test_nowarn @check(bar(2), nowarn=Any[], maxdepth=100) == 1.0
     @test_throws AssertionError @check(bar(2), nowarn=[bar])
     @test_throws AssertionError @check(bar(2), nowarn=[bar], maxdepth=100)
     @test_throws AssertionError @check(bar(2), nowarn=Any[bar])
     @test_throws AssertionError @check(bar(2), nowarn=Any[bar], maxdepth=100)
     @test_throws AssertionError @check(bar(2), nowarn=:all)
     @test_throws AssertionError @check(bar(2), nowarn=:all, maxdepth=100)
+    @test_nowarn @check(bar(2), nowarn=:allexcept, except=[bar]) == 1.0
+    @test_nowarn @check(bar(2), nowarn=:allexcept, except=[bar], maxdepth=100) == 1.0
+    @test_nowarn @check(bar(2), nowarn=:allexcept, except=Any[bar]) == 1.0
+    @test_nowarn @check(bar(2), nowarn=:allexcept, except=Any[bar], maxdepth=100) == 1.0
   end
 end


### PR DESCRIPTION
Pull request https://github.com/JunoLab/Traceur.jl/pull/32 added the ability to tell `@check`/`check` to throw an error if any warnings occur inside any function.

This pull request extends this functionality by adding the ability to tell `@check`/`check` to throw an error if any warnings occur inside any function EXCEPT those functions listed in the `except` array.

## Before this pull request
1. `@check f(x) nowarn=[g]`: throw an error if any warnings occur inside the function `g`
2. `@check f(x) nowarn=:all`: throw an error if any warnings occur inside any functions

## After this pull request
1. `@check f(x) nowarn=[g]`: throw an error if any warnings occur inside the function `g`
2. `@check f(x) nowarn=:all`: throw an error if any warnings occur inside any functions
3. `@check f(x) nowarn=:allexcept except=[h]`: throw an error if any warnings occur inside any functions EXCEPT the function `h`