### PR TITLE
use min_enabled_level()

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -10,7 +10,7 @@ for level in [:trace, :debug, :info, :warn, :error, :fatal]
             macrocall.args[1] = Symbol($"@$level")
             quote
                 old_logger = global_logger()
-                global_logger(Logging.ConsoleLogger(Core.stderr, old_logger.min_level))
+                global_logger(Logging.ConsoleLogger(Core.stderr, Logging.min_enabled_level(old_logger)))
                 ret = $(esc(macrocall))
                 global_logger(old_logger)
                 ret


### PR DESCRIPTION
Fix #47.
The `.min_level` property seems internal,
while [min_enabled_level()](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.min_enabled_level) is part of the standard interface.
