### PR TITLE
Wrap trace in with_logger()

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -9,10 +9,11 @@ for level in [:trace, :debug, :info, :warn, :error, :fatal]
             # NOTE: `@placeholder` in order to avoid hard-coding @__LINE__ etc
             macrocall.args[1] = Symbol($"@$level")
             quote
-                old_logger = global_logger()
-                global_logger(Logging.ConsoleLogger(Core.stderr, Logging.min_enabled_level(old_logger)))
-                ret = $(esc(macrocall))
-                global_logger(old_logger)
+                global_min_level = Logging.min_enabled_level(global_logger())
+                raw_logger = Logging.ConsoleLogger(Core.stderr, global_min_level)
+                Logging.with_logger(raw_logger) do
+	                global ret = $(esc(macrocall))
+                end
                 ret
             end
         end


### PR DESCRIPTION
As [suggested](https://github.com/JunoLab/Traceur.jl/issues/47#issuecomment-810772809) by @c42f,
wrap the trace call in `with_logger()`.

While we are at it, instead of the global logger, would [current_logger()](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.current_logger) be worth considering ?
